### PR TITLE
triage the README update script from fork

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Slash Command Dispatch
         uses: cloudposse/actions/github/slash-command-dispatch@0.12.0
         with:
-          token: ${{ secrets.GITHUB_BOT_TOKEN }}
+          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           repository: cloudposse/actions
           commands: rebuild-readme, terraform-fmt

--- a/README.yaml
+++ b/README.yaml
@@ -4,8 +4,6 @@
 # Run `make readme` to rebuild the `README.md`
 #
 
-# DELETE ME: triage the README update script from fork
-
 # Name of this project
 name: terraform-aws-elastic-beanstalk-environment
 

--- a/README.yaml
+++ b/README.yaml
@@ -4,6 +4,8 @@
 # Run `make readme` to rebuild the `README.md`
 #
 
+# DELETE ME: triage the README update script from fork
+
 # Name of this project
 name: terraform-aws-elastic-beanstalk-environment
 


### PR DESCRIPTION
## DO NOT MERGE!

## what
* triage the README update script from fork

## why
* readme update action failed with `[error]fatal: could not read Username for 'https://github.com': terminal prompts disabled`. this PR is to test previously working action run.

## references
* https://github.com/cloudposse/actions/runs/587642701?check_suite_focus=true
